### PR TITLE
Fix behavior of dates and times when persisting or fetching from DB.

### DIFF
--- a/src/com/clstephenson/DateTimeUtil.java
+++ b/src/com/clstephenson/DateTimeUtil.java
@@ -10,23 +10,39 @@ public class DateTimeUtil {
 
     private static String sqlDateTimeFormatString = "YYYY-MM-d HH:mm:s";
 
+    /**
+     * Used for saving a date/time to the DB.  Adds default timezone information before converting to UTC,
+     * and ultimately returns a timestamp for data persistence.
+     * @param localDateTime
+     * @return timestamp that can be persisted to a database
+     */
+    public static Timestamp getTimestampFromLocalDateTime(LocalDateTime localDateTime) {
+        ZonedDateTime zdt = localDateTime.atZone(ZoneId.systemDefault());
+        ZonedDateTime utc = zdt.withZoneSameInstant(ZoneId.of("UTC"));
+        localDateTime = utc.toLocalDateTime();
+        return Timestamp.valueOf(localDateTime);
+    }
+
+    /**
+     * Used for getting a date from the DB.  Converts a timestamp (e.g. from DB) to a ZonedDateTime using the
+     * system default timezone.
+     * @param timestamp
+     * @return date and time with default timezone information added
+     */
+    public static LocalDateTime getZonedDateTimeFromTimestamp(Timestamp timestamp) {
+        ZonedDateTime utc = timestamp.toLocalDateTime().atZone(ZoneId.of("UTC"));
+        return utc.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
+    }
+
     public static String getDateTimeForSQL() {
-        return LocalDateTime.now().format(getFormatter());
-    }
-
-    public static String getDateTimeForSQL(LocalDateTime localDateTime) {
-        return localDateTime.format(getFormatter());
-    }
-
-    public static LocalDateTime getZonedDateTimeFromSQLTimestamp(Timestamp timestamp) {
-        return LocalDateTime.ofInstant(timestamp.toInstant(), ZoneId.systemDefault());
+        return LocalDateTime.now().format(getDateTimeFormatter());
     }
 
     public static int getWeekOfYear(LocalDate date) {
         return date.get(WeekFields.of(Locale.getDefault()).weekOfWeekBasedYear());
     }
 
-    private static DateTimeFormatter getFormatter() {
+    private static DateTimeFormatter getDateTimeFormatter() {
         return DateTimeFormatter.ofPattern(sqlDateTimeFormatString);
     }
 

--- a/src/com/clstephenson/Main.java
+++ b/src/com/clstephenson/Main.java
@@ -15,6 +15,7 @@ import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;

--- a/src/com/clstephenson/dataaccess/AppointmentRepository.java
+++ b/src/com/clstephenson/dataaccess/AppointmentRepository.java
@@ -38,8 +38,8 @@ public class AppointmentRepository implements Repository<Appointment> {
                 statement.setString(4, appointment.getAppointmentLocation().name());
                 statement.setString(5, appointment.getConsultant());
                 statement.setString(6, appointment.getUrl());
-                statement.setObject(7, DateTimeUtil.getDateTimeForSQL(appointment.getStart()));
-                statement.setObject(8, DateTimeUtil.getDateTimeForSQL(appointment.getEnd()));
+                statement.setObject(7, DateTimeUtil.getTimestampFromLocalDateTime(appointment.getStart()));
+                statement.setObject(8, DateTimeUtil.getTimestampFromLocalDateTime(appointment.getEnd()));
                 statement.setObject(9, DateTimeUtil.getDateTimeForSQL());
                 statement.setString(10, currentUserName);
                 statement.setString(11, currentUserName);
@@ -70,8 +70,8 @@ public class AppointmentRepository implements Repository<Appointment> {
             statement.setString(4, appointment.getAppointmentLocation().name());
             statement.setString(5, appointment.getConsultant());
             statement.setString(6, appointment.getUrl());
-            statement.setObject(7, DateTimeUtil.getDateTimeForSQL(appointment.getStart()));
-            statement.setObject(8, DateTimeUtil.getDateTimeForSQL(appointment.getEnd()));
+            statement.setObject(7, DateTimeUtil.getTimestampFromLocalDateTime(appointment.getStart()));
+            statement.setObject(8, DateTimeUtil.getTimestampFromLocalDateTime(appointment.getEnd()));
             statement.setString(9, session.getLoggedInUser().getUserName());
             statement.setInt(10, appointment.getId());
             return statement.executeUpdate() > 0;
@@ -127,8 +127,8 @@ public class AppointmentRepository implements Repository<Appointment> {
         appointment.setAppointmentLocation(AppointmentLocation.valueOf(rs.getString("location")));
         appointment.setConsultant(rs.getString("contact"));
         appointment.setUrl(rs.getString("url"));
-        appointment.setStart(DateTimeUtil.getZonedDateTimeFromSQLTimestamp(rs.getTimestamp("start")));
-        appointment.setEnd(DateTimeUtil.getZonedDateTimeFromSQLTimestamp(rs.getTimestamp("end")));
+        appointment.setStart(DateTimeUtil.getZonedDateTimeFromTimestamp(rs.getTimestamp("start")));
+        appointment.setEnd(DateTimeUtil.getZonedDateTimeFromTimestamp(rs.getTimestamp("end")));
         return appointment;
     }
 

--- a/src/com/clstephenson/datamodels/Appointment.java
+++ b/src/com/clstephenson/datamodels/Appointment.java
@@ -8,6 +8,7 @@ import javafx.beans.property.*;
 
 import java.sql.SQLException;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 public class Appointment {
     private IntegerProperty id = new SimpleIntegerProperty(this, "id");


### PR DESCRIPTION
Changed methods in DateTimeUtil so that times will adjust automatically
based on the system default timezone.  Data is persisted as timestamps in UTC.

Related issue: #7